### PR TITLE
Flatten green patch at hole

### DIFF
--- a/game.js
+++ b/game.js
@@ -258,11 +258,17 @@ function drawGround() {
 }
 
 function drawHole() {
-  // green area
-  ctx.fillStyle = '#3cb371';
+  // green area - draw flattened ellipse and clip so nothing shows above ground
+  const vertRadius = hole.greenRadius * 0.5;
+  ctx.save();
   ctx.beginPath();
-  ctx.arc(hole.x, hole.y, hole.greenRadius, 0, Math.PI * 2);
+  ctx.rect(0, hole.y, canvas.width, canvas.height - hole.y);
+  ctx.clip();
+  ctx.beginPath();
+  ctx.ellipse(hole.x, hole.y, hole.greenRadius, vertRadius, 0, 0, Math.PI * 2);
+  ctx.fillStyle = '#3cb371';
   ctx.fill();
+  ctx.restore();
 
   // actual hole
   ctx.beginPath();


### PR DESCRIPTION
## Summary
- draw the putting green as a flattened ellipse
- clip anything above the ground so it shows the background

## Testing
- `node -e "require('./game.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68747e7d41588320af23f7128d0fda15