### PR TITLE
Add varied tree sizes and multiple trees per hole

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple browser golf game. Aim the ball and launch it toward the hole on a flat
 
 Open `index.html` in a web browser to access the home menu. Choose **Start Game** to play or read **About Game/Rules** for instructions. The game canvas will scale to your browser window. Use the left and right arrow keys to adjust the shot angle.
 An on-screen arrow shows your current aim direction. Press the Space key once to start the power meter and press again to launch the ball. Try to land it in the hole on the right side of the screen.
-Avoid trees, water, bunkers and hills along the way. The green around the hole is slicker, so the ball rolls farther. If your shot lands in the water hazard a penalty stroke is added and the ball is dropped on the side of the water farther from the hole.
+Avoid trees, water, bunkers and hills along the way. The green around the hole is slicker, so the ball rolls farther. Each hole may have between one and three trees that vary in size, so pay attention to your surroundings. If your shot lands in the water hazard a penalty stroke is added and the ball is dropped on the side of the water farther from the hole.
 Press **R** to reset the ball if you want to restart the current hole.
 
 The game now features 18 holes played in sequence. Each hole has a randomly

--- a/game.js
+++ b/game.js
@@ -14,6 +14,8 @@ const hole = {
 let obstacles = [];
 
 const BALL_RADIUS = 10;
+const TREE_BASE_WIDTH = 20;
+const TREE_BASE_HEIGHT = 60;
 const GROUND_THICKNESS = 20; // thickness of the ground from the bottom of the canvas
 
 const ball = {
@@ -97,7 +99,17 @@ function setupCourse() {
   }];
 
   obstacles = [];
-  obstacles.push(createObstacle('tree', canvas.width * 0.2, canvas.width * 0.4, { width: 20, height: 60 }, avoidGreen));
+  const treeCount = Math.floor(randomRange(1, 4));
+  for (let i = 0; i < treeCount; i++) {
+    const scale = randomRange(1.5, 3);
+    obstacles.push(createObstacle(
+      'tree',
+      canvas.width * 0.2,
+      canvas.width * 0.4,
+      { width: TREE_BASE_WIDTH * scale, height: TREE_BASE_HEIGHT * scale },
+      avoidGreen
+    ));
+  }
   // Water hazards should appear level with the ground so no depth is needed
   obstacles.push(createObstacle('water', canvas.width * 0.4, canvas.width * 0.6, { width: 60 }, avoidGreen));
   obstacles.push(createObstacle('bunker', canvas.width * 0.6, canvas.width * 0.8, { width: 80, depth: 12 }, avoidGreen));


### PR DESCRIPTION
## Summary
- allow holes to include multiple trees
- randomize tree size between 1.5x and 3x the original
- document that holes may have up to three trees

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68748d411c848320b6a6460cf6ad06d5