### PR TITLE
Fix yardage label for realistic distances

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ determined by its distance from the tee:
 - Par 4: 226–420yd
 - Par 5: 421–699yd
 
+Distances shown in the game are derived from the screen width using an
+approximate conversion of 0.3 yards per pixel so that each hole falls within a
+plausible real-world range.
+
 The overlay at the
 top of the screen shows the current hole number, its par and distance. Your
 strokes for each hole are recorded on the scoreboard shown on the right side of

--- a/game.js
+++ b/game.js
@@ -17,6 +17,8 @@ const BALL_RADIUS = 10;
 const TREE_BASE_WIDTH = 20;
 const TREE_BASE_HEIGHT = 60;
 const GROUND_THICKNESS = 20; // thickness of the ground from the bottom of the canvas
+// Rough conversion factor from pixels to yards for distance labels
+const PIXELS_TO_YARDS = 0.3;
 
 const ball = {
   x: 50,
@@ -102,7 +104,8 @@ function setupCourse() {
   // distance the ball can travel past the hole before penalty
   hole.maxOvershoot = randomRange(canvas.width * 0.2, canvas.width * 0.4);
   hole.maxDistance = hole.x + hole.maxOvershoot;
-  hole.distance = Math.round(hole.x - 50);
+  const pixelDist = hole.x - 50;
+  hole.distance = Math.round(pixelDist * PIXELS_TO_YARDS);
   if (hole.distance >= 75 && hole.distance <= 225) {
     hole.par = 3;
   } else if (hole.distance >= 226 && hole.distance <= 420) {


### PR DESCRIPTION
## Summary
- convert hole distance from pixels to yards with a constant scale
- clarify how yardage is calculated in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6875a2ceacac8320bec05fe56bb67015