### PR TITLE
Fix course elements not rendering

### DIFF
--- a/game.js
+++ b/game.js
@@ -726,6 +726,10 @@ window.addEventListener("keydown", (e) => {
   }
 });
 
+if (typeof window !== "undefined" && (typeof module === "undefined" || !module.exports)) {
+  loop();
+}
+
 if (typeof module !== "undefined" && module.exports) {
   /* global module */
   module.exports = {


### PR DESCRIPTION
## Summary
- ensure the game loop starts after setup completes
- avoid starting the loop during Jest tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6875a311ea908320bf5dc5b3f367458b