### PR TITLE
Allow obstacles to spawn anywhere

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,9 @@
 {
     "env": {
         "browser": true,
-        "es2021": true
+        "es2021": true,
+        "node": true,
+        "jest": true
     },
     "extends": "eslint:recommended",
     "parserOptions": {

--- a/game.js
+++ b/game.js
@@ -295,10 +295,6 @@ let bunkerPenaltyApplied = false;
 // how strongly gravity pulls the ball along slopes
 const SLOPE_ACCEL = 0.2;
 
-function smoothStep(t) {
-  return t * t * (3 - 2 * t);
-}
-
 function groundHeightAt(x) {
   let base = canvas.height - GROUND_THICKNESS;
   obstacles.forEach((o) => {
@@ -308,14 +304,6 @@ function groundHeightAt(x) {
       base -= height;
     }
   });
-
-  const dx = Math.abs(x - hole.x);
-  if (dx < hole.greenRadius) {
-    const flat = hole.greenRadius * 0.4;
-    const t =
-      dx <= flat ? 0 : smoothStep((dx - flat) / (hole.greenRadius - flat));
-    base = hole.y * (1 - t) + base * t;
-  }
 
   return base;
 }

--- a/game.js
+++ b/game.js
@@ -142,13 +142,6 @@ function setupCourse() {
   }
   obstacles.push(hill);
 
-  // carve a shallow bowl into the hill for the green
-  obstacles.push({
-    type: "hill",
-    x: hole.x - hole.greenRadius,
-    width: hole.greenRadius * 2,
-    height: -(hill.height * 0.3),
-  });
 
   // place water avoiding tee box, green and the hill
   const waterWidth = randomRange(80, 120);
@@ -189,6 +182,9 @@ function setupCourse() {
       ),
     );
   }
+
+  // ensure the cup sits at ground level
+  hole.y = groundHeightAt(hole.x);
 
   ball.x = 50;
   ball.y = canvas.height - GROUND_THICKNESS - BALL_RADIUS;
@@ -529,7 +525,7 @@ function drawHole() {
   ctx.restore();
 
   // actual hole
-  const groundY = groundHeightAt(hole.x);
+  const groundY = hole.y;
   ctx.save();
   ctx.beginPath();
   ctx.rect(0, groundY, canvas.width, canvas.height - groundY);

--- a/game.js
+++ b/game.js
@@ -142,6 +142,14 @@ function setupCourse() {
   }
   obstacles.push(hill);
 
+  // carve a shallow bowl into the hill for the green
+  obstacles.push({
+    type: "hill",
+    x: hole.x - hole.greenRadius,
+    width: hole.greenRadius * 2,
+    height: -(hill.height * 0.3),
+  });
+
   // place water avoiding tee box, green and the hill
   const waterWidth = randomRange(80, 120);
   const water = createObstacle(
@@ -505,22 +513,26 @@ function drawGround() {
 }
 
 function drawHole() {
-  // green area - draw flattened ellipse and clip so nothing shows above ground
-  const vertRadius = hole.greenRadius * 0.5;
+  // fill the green following the ground contour
+  const start = hole.x - hole.greenRadius;
+  const end = hole.x + hole.greenRadius;
   ctx.save();
   ctx.beginPath();
-  ctx.rect(0, hole.y, canvas.width, canvas.height - hole.y);
-  ctx.clip();
-  ctx.beginPath();
-  ctx.ellipse(hole.x, hole.y, hole.greenRadius, vertRadius, 0, 0, Math.PI * 2);
+  ctx.moveTo(start, canvas.height);
+  for (let x = start; x <= end; x += 2) {
+    ctx.lineTo(x, groundHeightAt(x));
+  }
+  ctx.lineTo(end, canvas.height);
+  ctx.closePath();
   ctx.fillStyle = "#3cb371";
   ctx.fill();
   ctx.restore();
 
   // actual hole
+  const groundY = groundHeightAt(hole.x);
   ctx.save();
   ctx.beginPath();
-  ctx.rect(0, hole.y, canvas.width, canvas.height - hole.y);
+  ctx.rect(0, groundY, canvas.width, canvas.height - groundY);
   ctx.clip();
   ctx.beginPath();
   ctx.arc(hole.x, hole.y, hole.radius + 3, 0, Math.PI * 2);

--- a/game.js
+++ b/game.js
@@ -644,7 +644,7 @@ function drawObstacles() {
         ctx.lineTo(x, groundHeightAt(x));
       }
       for (let x = o.x + o.width; x >= o.x; x -= 2) {
-        ctx.lineTo(x, groundHeightAt(x) - o.depth);
+        ctx.lineTo(x, groundHeightAt(x) + o.depth);
       }
       ctx.closePath();
       ctx.fill();
@@ -746,7 +746,6 @@ if (typeof window !== "undefined" && (typeof module === "undefined" || !module.e
 }
 
 if (typeof module !== "undefined" && module.exports) {
-  /* global module */
   module.exports = {
     randomRange,
     obstacleRange,

--- a/game.js
+++ b/game.js
@@ -128,14 +128,13 @@ function setupCourse() {
 
   obstacles = [];
 
-  // first place a hill anywhere on the course
-  const hill = createObstacle(
-    "hill",
-    0,
-    courseEnd * 0.8,
-    { width: randomRange(80, 140), height: randomRange(30, 50) },
-    [],
-  );
+  // create a broad rolling hill across most of the course
+  const hill = {
+    type: "hill",
+    x: 0,
+    width: courseEnd,
+    height: randomRange(40, 80),
+  };
   if (hill.x < TEE_BOX_WIDTH) {
     const diff = TEE_BOX_WIDTH - hill.x;
     hill.x = TEE_BOX_WIDTH;
@@ -144,11 +143,12 @@ function setupCourse() {
   obstacles.push(hill);
 
   // place water avoiding tee box, green and the hill
+  const waterWidth = randomRange(80, 120);
   const water = createObstacle(
     "water",
     TEE_BOX_WIDTH,
     courseEnd * 0.7,
-    { width: 80 },
+    { width: waterWidth },
     [teeRange, ...avoidGreen, { left: hill.x, right: hill.x + hill.width }],
   );
   obstacles.push(water);
@@ -172,7 +172,12 @@ function setupCourse() {
         TEE_BOX_WIDTH,
         courseEnd * 0.9,
         { width: TREE_BASE_WIDTH * scale, height: TREE_BASE_HEIGHT * scale },
-        [teeRange, ...avoidGreen],
+        [
+          teeRange,
+          ...avoidGreen,
+          { left: water.x, right: water.x + water.width },
+          { left: bunker.x, right: bunker.x + bunker.width },
+        ],
       ),
     );
   }

--- a/game.js
+++ b/game.js
@@ -128,10 +128,12 @@ function setupCourse() {
   obstacles = [];
 
   // create a broad rolling hill across most of the course
+  const hillWidth = randomRange(courseEnd * 0.3, courseEnd * 0.6);
+  let hillX = randomRange(0, courseEnd - hillWidth);
   const hill = {
     type: "hill",
-    x: 0,
-    width: courseEnd,
+    x: hillX,
+    width: hillWidth,
     height: randomRange(40, 80),
   };
   if (hill.x < TEE_BOX_WIDTH) {

--- a/game.js
+++ b/game.js
@@ -144,14 +144,14 @@ function setupCourse() {
   obstacles.push(hill);
 
 
-  // place water avoiding tee box, green and the hill
+  // place water avoiding tee box, green and other water/bunkers
   const waterWidth = randomRange(80, 120);
   const water = createObstacle(
     "water",
     TEE_BOX_WIDTH,
     courseEnd * 0.7,
     { width: waterWidth },
-    [teeRange, ...avoidGreen, { left: hill.x, right: hill.x + hill.width }],
+    [teeRange, ...avoidGreen],
   );
   if (water) obstacles.push(water);
 


### PR DESCRIPTION
## Summary
- tweak course setup so trees, water, sand and hills can appear across the course
- block obstacles from the tee box using a `TEE_BOX_WIDTH` constant
- enlarge the water hazard

## Testing
- `npm test`
- `npm run lint` *(fails: many `no-undef` errors)*

------
https://chatgpt.com/codex/tasks/task_b_6875acee5d688320a5f74b7590f8a0ff