### PR TITLE
Move camera left when ball travels left of tee

### DIFF
--- a/game.js
+++ b/game.js
@@ -497,7 +497,8 @@ function update() {
     }
   } else {
     if (ball.x - viewOffset < 100) {
-      viewOffset = Math.max(0, ball.x - 100);
+      // allow negative offsets so the camera can pan left of the tee
+      viewOffset = ball.x - 100;
     }
   }
 


### PR DESCRIPTION
## Summary
- allow camera offset to become negative when the ball goes left of the tee

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68765c8ea2808320883c2025d83fc997