### PR TITLE
Add about pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About JS Games</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="menu">
+      <h1>About JS Games</h1>
+      <p>JS Games is a collection of small browser games written in JavaScript.</p>
+      <p>The current lineup includes:</p>
+      <ul>
+        <li>2D Golf &ndash; aim the ball and try to finish 18 holes under par.</li>
+        <li>The Maze &ndash; navigate through a series of increasingly large mazes.</li>
+        <li>Baseball Game &ndash; time your swing to hit the pitched ball.</li>
+        <li>Stick Figure Fighting &ndash; defeat the AI opponent using simple moves.</li>
+      </ul>
+      <a href="index.html">Back to Home</a>
+    </div>
+    <script src="theme.js"></script>
+  </body>
+</html>

--- a/games/baseball/about.html
+++ b/games/baseball/about.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About Baseball Game</title>
+    <link rel="stylesheet" href="../../style.css" />
+  </head>
+  <body>
+    <div id="menu">
+      <h1>About Baseball Game</h1>
+      <p>Time your swing to hit the pitched ball as it crosses the plate.</p>
+      <p>Press the <strong>Space</strong> key to swing the bat.</p>
+      <a href="baseball.html">Back to Game</a>
+      <a href="../../index.html">Home</a>
+    </div>
+    <script src="../../theme.js"></script>
+  </body>
+</html>

--- a/games/baseball/baseball.html
+++ b/games/baseball/baseball.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <a id="homeLink" href="../../index.html">Back to Home</a>
+    <a id="aboutLink" href="about.html">About Game</a>
     <div id="overlay">
       <h1>Baseball Game</h1>
       <p>Press Space to swing when the ball reaches you.</p>

--- a/games/golf/about.html
+++ b/games/golf/about.html
@@ -32,7 +32,8 @@
       <!-- Version numbers follow MAJOR.MINOR.PATCH with optional prerelease
            labels like -alpha for early builds. -->
       <p id="version">Version 0.1.0-alpha – this is an alpha release.</p>
-      <a href="../../index.html">Back to Home</a>
+      <a href="game.html">Back to Game</a>
+      <a href="../../index.html">Home</a>
     </div>
     <script src="../../theme.js"></script>
   </body>

--- a/games/golf/game.html
+++ b/games/golf/game.html
@@ -24,6 +24,7 @@
     </div>
     <div id="powerBar"><div id="powerLevel"></div></div>
     <a id="homeLink" href="../../index.html">Back to Home</a>
+    <a id="aboutLink" href="about.html">About Game</a>
     <canvas id="game"></canvas>
     <script src="game.js"></script>
     <script src="../../theme.js"></script>

--- a/games/maze/about.html
+++ b/games/maze/about.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About The Maze</title>
+    <link rel="stylesheet" href="../../style.css" />
+  </head>
+  <body>
+    <div id="menu">
+      <h1>About The Maze</h1>
+      <p>Navigate the ball through procedurally generated mazes.</p>
+      <p>Each of the five levels grows larger and uses a different color scheme.</p>
+      <p>Reach the exit to advance and escape the final maze to win.</p>
+      <a href="maze.html">Back to Game</a>
+      <a href="../../index.html">Home</a>
+    </div>
+    <script src="../../theme.js"></script>
+  </body>
+</html>

--- a/games/maze/maze.html
+++ b/games/maze/maze.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <a id="homeLink" href="../../index.html">Back to Home</a>
+    <a id="aboutLink" href="about.html">About Game</a>
     <div id="overlay">
       <h1>The Maze</h1>
       <p>Use the arrow keys to move the ball to the exit.</p>

--- a/games/stickfight/about.html
+++ b/games/stickfight/about.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About Stick Figure Fighting</title>
+    <link rel="stylesheet" href="../../style.css" />
+  </head>
+  <body>
+    <div id="menu">
+      <h1>About Stick Figure Fighting</h1>
+      <p>Battle an AI opponent using simple controls.</p>
+      <p>Move with the arrow keys, press <strong>A</strong> to attack and hold <strong>S</strong> to block.</p>
+      <p>Each fighter can take about five hits before being defeated.</p>
+      <a href="stickfight.html">Back to Game</a>
+      <a href="../../index.html">Home</a>
+    </div>
+    <script src="../../theme.js"></script>
+  </body>
+</html>

--- a/games/stickfight/stickfight.html
+++ b/games/stickfight/stickfight.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <a id="homeLink" href="../../index.html">Back to Home</a>
+    <a id="aboutLink" href="about.html">About Game</a>
     <div id="overlay">
       <h1>Stick Figure Fighting</h1>
       <p>Use ←/→ to move, ↑ to jump. Press A to attack and hold S to block.</p>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         <li><a href="games/maze/maze.html">The Maze</a></li>
         <li><a href="games/baseball/baseball.html">Baseball Game</a></li>
         <li><a href="games/stickfight/stickfight.html">Stick Figure Fighting</a></li>
-        <li><a href="games/golf/about.html">About 2D Golf</a></li>
+        <li><a href="about.html">About JS Games</a></li>
         <li><a href="games/golf/settings.html">Settings</a></li>
       </ul>
     </div>

--- a/style.css
+++ b/style.css
@@ -159,7 +159,8 @@ body {
 }
 
 /* link back to home page on game screen */
-#homeLink {
+#homeLink,
+#aboutLink {
   position: absolute;
   top: 10px;
   left: 10px;
@@ -170,7 +171,11 @@ body {
   text-decoration: none;
   color: var(--text-color);
 }
-#homeLink:hover {
+#aboutLink {
+  left: 110px;
+}
+#homeLink:hover,
+#aboutLink:hover {
   background: var(--link-hover-bg);
 }
 


### PR DESCRIPTION
## Summary
- add a site-wide About page
- create About pages for Baseball, Maze and Stick Fight
- link back to each new About page from its game
- include link to JS Games About page on home page
- tweak styles to support About link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687c5c7c61d083208d5ff53bfe5274bf