### PR TITLE
Add escape menu for game links

### DIFF
--- a/games/archery/archery.html
+++ b/games/archery/archery.html
@@ -7,8 +7,10 @@
     <link rel="stylesheet" href="../../style.css" />
   </head>
   <body>
-    <a id="homeLink" href="../../index.html">Back to Home</a>
-    <a id="aboutLink" href="about.html">About Game</a>
+    <div id="gameMenu">
+      <a id="homeLink" href="../../index.html">Back to Home</a>
+      <a id="aboutLink" href="about.html">About Game</a>
+    </div>
     <div id="overlay">
       <h1>Archery Darts</h1>
       <p>Use the left/right arrows to aim. Press Space to shoot.</p>
@@ -17,5 +19,6 @@
     <canvas id="archery"></canvas>
     <script src="archery.js"></script>
     <script src="../../theme.js"></script>
+    <script src="../../menu.js"></script>
   </body>
 </html>

--- a/games/baseball/baseball.html
+++ b/games/baseball/baseball.html
@@ -7,8 +7,10 @@
     <link rel="stylesheet" href="../../style.css" />
   </head>
   <body>
-    <a id="homeLink" href="../../index.html">Back to Home</a>
-    <a id="aboutLink" href="about.html">About Game</a>
+    <div id="gameMenu">
+      <a id="homeLink" href="../../index.html">Back to Home</a>
+      <a id="aboutLink" href="about.html">About Game</a>
+    </div>
     <div id="overlay">
       <h1>Baseball Game</h1>
       <p>Press Space to swing when the ball reaches you.</p>
@@ -18,5 +20,6 @@
     <canvas id="baseball"></canvas>
     <script src="baseball.js"></script>
     <script src="../../theme.js"></script>
+    <script src="../../menu.js"></script>
   </body>
 </html>

--- a/games/golf/game.html
+++ b/games/golf/game.html
@@ -23,10 +23,13 @@
       <p id="totalScore"></p>
     </div>
     <div id="powerBar"><div id="powerLevel"></div></div>
-    <a id="homeLink" href="../../index.html">Back to Home</a>
-    <a id="aboutLink" href="about.html">About Game</a>
+    <div id="gameMenu">
+      <a id="homeLink" href="../../index.html">Back to Home</a>
+      <a id="aboutLink" href="about.html">About Game</a>
+    </div>
     <canvas id="game"></canvas>
     <script src="game.js"></script>
     <script src="../../theme.js"></script>
+    <script src="../../menu.js"></script>
   </body>
 </html>

--- a/games/maze/maze.html
+++ b/games/maze/maze.html
@@ -7,8 +7,10 @@
     <link rel="stylesheet" href="../../style.css" />
   </head>
   <body>
-    <a id="homeLink" href="../../index.html">Back to Home</a>
-    <a id="aboutLink" href="about.html">About Game</a>
+    <div id="gameMenu">
+      <a id="homeLink" href="../../index.html">Back to Home</a>
+      <a id="aboutLink" href="about.html">About Game</a>
+    </div>
     <div id="overlay">
       <h1>The Maze</h1>
       <p>Use the arrow keys to move the ball to the exit.</p>
@@ -18,5 +20,6 @@
     <canvas id="maze"></canvas>
     <script src="maze.js"></script>
     <script src="../../theme.js"></script>
+    <script src="../../menu.js"></script>
   </body>
 </html>

--- a/games/stickfight/stickfight.html
+++ b/games/stickfight/stickfight.html
@@ -7,8 +7,10 @@
     <link rel="stylesheet" href="../../style.css" />
   </head>
   <body>
-    <a id="homeLink" href="../../index.html">Back to Home</a>
-    <a id="aboutLink" href="about.html">About Game</a>
+    <div id="gameMenu">
+      <a id="homeLink" href="../../index.html">Back to Home</a>
+      <a id="aboutLink" href="about.html">About Game</a>
+    </div>
     <div id="overlay">
       <h1>Stick Figure Fighting</h1>
       <p>Use ←/→ to move, ↑ to jump. Press A to attack and hold S to block.</p>
@@ -17,5 +19,6 @@
     <canvas id="stickfight"></canvas>
     <script src="stickfight.js"></script>
     <script src="../../theme.js"></script>
+    <script src="../../menu.js"></script>
   </body>
 </html>

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,16 @@
+function initEscapeMenu() {
+  const menu = document.getElementById("gameMenu");
+  if (!menu) return;
+  let visible = false;
+  function toggle() {
+    visible = !visible;
+    menu.style.display = visible ? "block" : "none";
+  }
+  document.addEventListener("keydown", (e) => {
+    if (e.code === "Escape") {
+      toggle();
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", initEscapeMenu);

--- a/style.css
+++ b/style.css
@@ -158,25 +158,38 @@ body {
   background: var(--link-hover-bg);
 }
 
-/* link back to home page on game screen */
+/* links inside escape menu */
 #homeLink,
 #aboutLink {
-  position: absolute;
-  top: 10px;
-  left: 10px;
+  display: block;
+  margin: 10px 0;
   padding: 5px 10px;
   background: var(--overlay-bg);
   border: 1px solid var(--border-color);
   border-radius: 5px;
   text-decoration: none;
   color: var(--text-color);
-}
-#aboutLink {
-  left: 110px;
+  width: max-content;
+  margin-left: auto;
+  margin-right: auto;
 }
 #homeLink:hover,
 #aboutLink:hover {
   background: var(--link-hover-bg);
+}
+
+/* escape key menu container */
+#gameMenu {
+  display: none;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--overlay-bg);
+  border: 1px solid var(--border-color);
+  padding: 20px;
+  text-align: center;
+  z-index: 1000;
 }
 
 #themeToggle {


### PR DESCRIPTION
## Summary
- replace per-game home/about links with a hidden menu
- show that menu when pressing `Escape`
- style the menu overlay
- add menu script used by all games

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687eafc4e6f88320a4c6bb2c3b7ff865