### PR TITLE
Enhance blackjack with buttons and card graphics

### DIFF
--- a/games/blackjack/about.html
+++ b/games/blackjack/about.html
@@ -13,8 +13,8 @@
       <p>
         Press <strong>D</strong> to deal, <strong>H</strong> to hit,
         <strong>S</strong> to stand, <strong>P</strong> to split pairs and
-        <strong>X</strong> to double down. You start with $500 in chips and may
-        bet up to $25 each round.
+        <strong>X</strong> to double down or use the on-screen buttons. You
+        start with $500 in chips and may bet up to $25 each round.
       </p>
       <a href="blackjack.html">Back to Game</a>
       <a href="../../index.html">Home</a>

--- a/games/blackjack/blackjack.html
+++ b/games/blackjack/blackjack.html
@@ -15,13 +15,20 @@
       <h1>Black Jack</h1>
       <p>
         Press D to deal, H to hit, S to stand, P to split pairs and X to double
-        down. Max bet $25.
+        down. You can also use the buttons below. Max bet $25.
       </p>
       <p id="chips"></p>
       <p id="betDisplay"></p>
-      <p id="dealerHand"></p>
-      <p id="playerHand"></p>
+      <div id="dealerHand" class="hand"></div>
+      <div id="playerHands"></div>
       <p id="message"></p>
+      <div id="controls">
+        <button id="dealBtn">Deal</button>
+        <button id="hitBtn">Hit</button>
+        <button id="standBtn">Stand</button>
+        <button id="doubleBtn">Double</button>
+        <button id="splitBtn">Split</button>
+      </div>
     </div>
     <canvas id="blackjack"></canvas>
     <script src="blackjack.js"></script>

--- a/style.css
+++ b/style.css
@@ -210,3 +210,38 @@ body {
 #themeToggle:hover {
   background: var(--link-hover-bg);
 }
+/* blackjack card and control styles */
+.hand {
+  display: inline-block;
+  margin: 5px;
+}
+.card {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 60px;
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  background: #fff;
+  margin: 2px;
+  font-weight: bold;
+}
+[data-theme="dark"] .card {
+  background: #222;
+}
+.card.red {
+  color: red;
+}
+.card.back {
+  background: var(--border-color);
+  color: transparent;
+}
+#controls {
+  pointer-events: auto;
+  margin-top: 10px;
+}
+#controls button {
+  margin: 0 5px;
+  padding: 5px 10px;
+}


### PR DESCRIPTION
## Summary
- add interactive buttons to Blackjack UI
- implement a full card deck with suits and ranks
- render hands with visual cards and display split hands
- support mouse controls in addition to keyboard
- tweak styling for cards and control area

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687ee70971808320b20097576671966d