### PR TITLE
Add solitaire game

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ a chip and right click to remove one before spinning. A correct bet pays 35:1.
 Roll the ball down the lane and knock down pins. Scores are calculated using
 standard bowling rules.
 
+## Solitaire
+
+Move cards between the tableau, waste and four foundations to build each suit in order.
+
 ## Playing
 
 Open `index.html` in a web browser to access the home menu. Choose **Start Game** to play or read **About Game/Rules** for instructions. The game canvas will scale to your browser window. Use the left and right arrow keys to adjust the shot angle. The controls are inverted so the left arrow rotates the aim right and the right arrow rotates it left.

--- a/about.html
+++ b/about.html
@@ -34,6 +34,7 @@
           Bowling Game &ndash; roll the ball at pins and score using bowling
           rules.
         </li>
+        <li>Solitaire &ndash; build up the four foundations to win.</li>
       </ul>
       <a href="index.html">Back to Home</a>
     </div>

--- a/games/solitaire/about.html
+++ b/games/solitaire/about.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About Solitaire</title>
+    <link rel="stylesheet" href="../../style.css" />
+  </head>
+  <body>
+    <div id="menu">
+      <h1>About Solitaire</h1>
+      <p>Build up four foundation piles from Ace to King.</p>
+      <p>Click the stock pile to draw a card. Select cards by clicking them and
+         then click a destination pile to move.</p>
+      <a href="solitaire.html">Back to Game</a>
+      <a href="../../index.html">Home</a>
+    </div>
+    <script src="../../theme.js"></script>
+  </body>
+</html>

--- a/games/solitaire/solitaire.html
+++ b/games/solitaire/solitaire.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Solitaire</title>
+    <link rel="stylesheet" href="../../style.css" />
+  </head>
+  <body>
+    <div id="gameMenu">
+      <a id="homeLink" href="../../index.html">Back to Home</a>
+      <a id="aboutLink" href="about.html">About Game</a>
+    </div>
+    <div id="overlay">
+      <h1>Solitaire</h1>
+      <p>Click the deck to draw and move cards to build four foundations.</p>
+      <p id="message"></p>
+    </div>
+    <div id="solitaire"></div>
+    <script src="solitaire.js"></script>
+    <script src="../../theme.js"></script>
+    <script src="../../menu.js"></script>
+  </body>
+</html>

--- a/games/solitaire/solitaire.js
+++ b/games/solitaire/solitaire.js
@@ -1,0 +1,276 @@
+const board = document.getElementById("solitaire");
+const messageEl = document.getElementById("message");
+
+const SUITS = ["♠", "♥", "♦", "♣"];
+const RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"];
+
+function rankValue(rank) {
+  return RANKS.indexOf(rank) + 1;
+}
+
+function cardColor(suit) {
+  return suit === "♥" || suit === "♦" ? "red" : "black";
+}
+
+let stock = [];
+let waste = [];
+let foundations = [[], [], [], []];
+let tableau = [[], [], [], [], [], [], []];
+let selected = null;
+
+function createDeck() {
+  const deck = [];
+  SUITS.forEach((suit) => {
+    RANKS.forEach((rank) => deck.push({ suit, rank, faceUp: false }));
+  });
+  return deck;
+}
+
+function shuffle(deck) {
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+}
+
+function setup() {
+  const deck = createDeck();
+  shuffle(deck);
+  for (let i = 0; i < 7; i++) {
+    tableau[i] = [];
+    for (let j = 0; j <= i; j++) {
+      const card = deck.pop();
+      card.faceUp = j === i;
+      tableau[i].push(card);
+    }
+  }
+  stock = deck;
+  waste = [];
+  foundations = [[], [], [], []];
+  selected = null;
+  render();
+}
+
+function drawFromStock() {
+  if (stock.length) {
+    const card = stock.pop();
+    card.faceUp = true;
+    waste.push(card);
+  } else {
+    stock = waste.reverse();
+    stock.forEach((c) => (c.faceUp = false));
+    waste = [];
+  }
+  render();
+}
+
+function canMoveToFoundation(card, foundation) {
+  if (!foundation.length) return card.rank === "A";
+  const top = foundation[foundation.length - 1];
+  return top.suit === card.suit && rankValue(card.rank) === rankValue(top.rank) + 1;
+}
+
+function canMoveToTableau(cards, pile) {
+  const card = cards[0];
+  if (!pile.length) return card.rank === "K";
+  const top = pile[pile.length - 1];
+  return (
+    cardColor(card.suit) !== cardColor(top.suit) &&
+    rankValue(card.rank) === rankValue(top.rank) - 1
+  );
+}
+
+function flipOrigin(sel) {
+  if (sel.type === "tableau") {
+    const pile = tableau[sel.pile];
+    if (pile.length && !pile[pile.length - 1].faceUp) {
+      pile[pile.length - 1].faceUp = true;
+    }
+  }
+}
+
+function attemptMove(sel, target) {
+  let cards;
+  if (sel.type === "waste") {
+    cards = [waste[waste.length - 1]];
+  } else {
+    cards = tableau[sel.pile].slice(sel.index);
+  }
+
+  if (target.pile === "foundation") {
+    if (cards.length !== 1) return false;
+    const foundation = foundations[target.index];
+    if (canMoveToFoundation(cards[0], foundation)) {
+      if (sel.type === "waste") waste.pop();
+      else tableau[sel.pile].splice(sel.index, cards.length);
+      foundation.push(cards[0]);
+      flipOrigin(sel);
+      return true;
+    }
+  }
+
+  if (target.pile === "tableau") {
+    const dest = tableau[target.index];
+    if (canMoveToTableau(cards, dest)) {
+      if (sel.type === "waste") waste.pop();
+      else tableau[sel.pile].splice(sel.index, cards.length);
+      dest.push(...cards);
+      flipOrigin(sel);
+      return true;
+    }
+  }
+  return false;
+}
+
+function createCardElement(card, pile, pileIndex, cardIndex) {
+  const div = document.createElement("div");
+  div.className = "card";
+  if (!card.faceUp) {
+    div.classList.add("back");
+    div.textContent = "?";
+  } else {
+    if (cardColor(card.suit) === "red") div.classList.add("red");
+    div.textContent = `${card.rank}${card.suit}`;
+  }
+  div.dataset.pile = pile;
+  div.dataset.index = pileIndex;
+  div.dataset.card = cardIndex;
+  div.style.top = pile === "tableau" ? `${cardIndex * 20}px` : "0";
+  div.addEventListener("click", (e) => {
+    e.stopPropagation();
+    onCardClick(pile, pileIndex, cardIndex);
+  });
+  if (
+    selected &&
+    selected.type === pile &&
+    selected.pile === pileIndex &&
+    ((pile === "tableau" && cardIndex >= selected.index) || pile !== "tableau")
+  ) {
+    div.classList.add("selected");
+  }
+  return div;
+}
+
+function onCardClick(pile, pileIndex, cardIndex) {
+  if (pile === "stock") {
+    drawFromStock();
+    return;
+  }
+
+  if (selected) {
+    if (attemptMove(selected, { pile, index: pileIndex })) {
+      selected = null;
+      render();
+    } else if (pile === selected.type && pileIndex === selected.pile) {
+      selected = null;
+      render();
+    } else {
+      selected = null;
+      render();
+    }
+    return;
+  }
+
+  if (pile === "waste") {
+    if (waste.length) {
+      selected = { type: "waste" };
+      render();
+    }
+    return;
+  }
+
+  if (pile === "tableau") {
+    const card = tableau[pileIndex][cardIndex];
+    if (!card.faceUp) {
+      if (cardIndex === tableau[pileIndex].length - 1) {
+        card.faceUp = true;
+        render();
+      }
+      return;
+    }
+    selected = { type: "tableau", pile: pileIndex, index: cardIndex };
+    render();
+  }
+}
+
+function checkWin() {
+  if (foundations.every((f) => f.length === 13)) {
+    messageEl.textContent = "You win!";
+  } else {
+    messageEl.textContent = "";
+  }
+}
+
+function render() {
+  board.innerHTML = "";
+  const topRow = document.createElement("div");
+  topRow.id = "topRow";
+  board.appendChild(topRow);
+
+  const stockDiv = document.createElement("div");
+  stockDiv.id = "stock";
+  stockDiv.className = "pile";
+  stockDiv.addEventListener("click", drawFromStock);
+  if (stock.length) {
+    const back = document.createElement("div");
+    back.className = "card back";
+    stockDiv.appendChild(back);
+  }
+  topRow.appendChild(stockDiv);
+
+  const wasteDiv = document.createElement("div");
+  wasteDiv.id = "waste";
+  wasteDiv.className = "pile";
+  wasteDiv.addEventListener("click", () => onCardClick("waste", 0, 0));
+  if (waste.length) {
+    const card = waste[waste.length - 1];
+    const cardEl = createCardElement(card, "waste", 0, waste.length - 1);
+    cardEl.style.position = "static";
+    wasteDiv.appendChild(cardEl);
+  }
+  topRow.appendChild(wasteDiv);
+
+  const spacer = document.createElement("div");
+  spacer.style.flex = "1";
+  topRow.appendChild(spacer);
+
+  for (let i = 0; i < 4; i++) {
+    const fDiv = document.createElement("div");
+    fDiv.className = "pile foundation";
+    fDiv.addEventListener("click", () => onCardClick("foundation", i, 0));
+    if (foundations[i].length) {
+      const card = foundations[i][foundations[i].length - 1];
+      const el = createCardElement(card, "foundation", i, foundations[i].length - 1);
+      el.style.position = "static";
+      fDiv.appendChild(el);
+    }
+    topRow.appendChild(fDiv);
+  }
+
+  const tableauRow = document.createElement("div");
+  tableauRow.id = "tableauRow";
+  board.appendChild(tableauRow);
+
+  for (let i = 0; i < 7; i++) {
+    const tDiv = document.createElement("div");
+    tDiv.className = "pile tableau";
+    tDiv.addEventListener("click", (e) => {
+      if (e.target === tDiv && selected) {
+        if (attemptMove(selected, { pile: "tableau", index: i })) {
+          selected = null;
+          render();
+        }
+      }
+    });
+    const pile = tableau[i];
+    for (let j = 0; j < pile.length; j++) {
+      const c = pile[j];
+      const el = createCardElement(c, "tableau", i, j);
+      tDiv.appendChild(el);
+    }
+    tableauRow.appendChild(tDiv);
+  }
+  checkWin();
+}
+
+setup();

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
         <li><a href="games/blackjack/blackjack.html">Black Jack</a></li>
         <li><a href="games/roulette/roulette.html">Roulette</a></li>
         <li><a href="games/bowling/bowling.html">Bowling Game</a></li>
+        <li><a href="games/solitaire/solitaire.html">Solitaire</a></li>
         <li><a href="about.html">About JS Games</a></li>
         <li><a href="games/golf/settings.html">Settings</a></li>
       </ul>

--- a/style.css
+++ b/style.css
@@ -291,3 +291,39 @@ body {
 .roulette-cell.green {
   background: green;
 }
+
+#solitaire {
+  background: var(--game-bg);
+  width: 100vw;
+  height: 100vh;
+  position: relative;
+}
+
+#topRow,
+#tableauRow {
+  display: flex;
+  margin: 10px;
+}
+
+.pile {
+  position: relative;
+  width: 80px;
+  min-height: 80px;
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  margin-right: 10px;
+  pointer-events: auto;
+}
+
+.foundation {
+  width: 60px;
+}
+
+.pile .card {
+  position: absolute;
+  left: 0;
+}
+
+.selected {
+  outline: 2px solid blue;
+}


### PR DESCRIPTION
## Summary
- add new Solitaire game with playing field and classic rules
- style card piles and selected cards
- list Solitaire in the home menu and about page
- document the game in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68828945abfc832082601713cfc7629c