### PR TITLE
Ensure dark mode toggle button uses light text

### DIFF
--- a/style.css
+++ b/style.css
@@ -220,6 +220,7 @@ body {
   border-radius: 5px;
   cursor: pointer;
   margin-top: 20px;
+  color: var(--text-color);
 }
 #themeToggle:hover {
   background: var(--link-hover-bg);


### PR DESCRIPTION
## Summary
- match dark mode toggle button text color to home link for improved contrast

## Testing
- `npm test`
- `npm run lint` *(fails: 'jest', 'test', and other globals undefined)*

------
https://chatgpt.com/codex/tasks/task_b_688d8753fa088320854836c14f75eeb7